### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Imports:
     logspline,
     mvtnorm,
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1)
 Suggests: 
     testthat,
@@ -57,8 +57,8 @@ LinkingTo:
     Rcpp (>= 1.0.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 VignetteBuilder: knitr
 URL: https://github.com/danheck/metaBMA, https://danheck.github.io/metaBMA/
 License: GPL-3

--- a/inst/stan/jzs/data.stan
+++ b/inst/stan/jzs/data.stan
@@ -1,7 +1,7 @@
 int<lower=1> B;                       // number of JZS blocks
-int<lower=1> P[B];                    // number of predictors per block
-int<lower=1,upper=sum(P)> b_idx[B,2]; // start-end index per JZS block for beta / X cols
+array[B] int<lower=1> P;                    // number of predictors per block
+array[B,2] int<lower=1,upper=sum(P)> b_idx; // start-end index per JZS block for beta / X cols
 
 vector<lower=0>[B] rscale;            // prior scaling for JZS blocks
 matrix[N,sum(P)] X;                   // design matrix  (centered)
-matrix[max(P),max(P)] L[B];           // lower triangular cholesky of:  C=inverse(covariance(X))
+array[B] matrix[max(P),max(P)] L;           // lower triangular cholesky of:  C=inverse(covariance(X))


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
